### PR TITLE
Set version to 1.1.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 
 pluginName = OPENRNDR
 
-pluginVersion = 1.1.4
+pluginVersion = 1.1.3
 
 # Opt-out flag for bundling Kotlin standard library -> https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
Accidentally bumped the version number twice, so we'd be skipping a patch release without this PR.