### PR TITLE
Fix tests to use current version of openrndr

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,7 +73,6 @@ tasks {
             "idea.home.path" to (System.getenv("INTELLIJ_SOURCES") ?: defaultIntellijSourcesPath),
             "version_used_for.openrndr" to libs.versions.openrndr.get(),
             "version_used_for.orx" to libs.versions.orx.get(),
-            "version_used_for.kotlin" to libs.versions.kotlin.get()
         )
     }
 

--- a/src/test/kotlin/org/openrndr/plugin/intellij/ColorRGBaTestCase.kt
+++ b/src/test/kotlin/org/openrndr/plugin/intellij/ColorRGBaTestCase.kt
@@ -31,13 +31,8 @@ abstract class ColorRGBaTestCase : BasePlatformTestCase() {
     companion object {
         protected val PROJECT_DESCRIPTOR = DefaultLightProjectDescriptor(
             { IdeaTestUtil.getMockJdk17() }, listOf(
-                // Fixed to 0.4.3-alpha5 because openrndr no longer uses `kotlin.mpp.enableCompatibilityMetadataVariant`
-                // which breaks dependency resolution for these tests.
-                "org.openrndr:openrndr-color:0.4.3-alpha5",
-                "org.openrndr.extra:orx-color:0.4.3-alpha5",
-                // This isn't getting pulled in as a transitive dependency from orx-color for
-                // some reason, so we add it manually.
-                "org.jetbrains.kotlin:kotlin-stdlib-common:${System.getProperty("version_used_for.kotlin")}"
+                "org.openrndr:openrndr-color-jvm:${System.getProperty("version_used_for.openrndr")}",
+                "org.openrndr.extra:orx-color-jvm:${System.getProperty("version_used_for.orx")}",
             )
         )
 

--- a/src/test/kotlin/org/openrndr/plugin/intellij/editor/ColorRGBaColorProviderTest.kt
+++ b/src/test/kotlin/org/openrndr/plugin/intellij/editor/ColorRGBaColorProviderTest.kt
@@ -19,9 +19,10 @@ class ColorRGBaColorProviderTest : ColorRGBaTestCase() {
     private fun assertGutterIconColorManual(expected: Color, code: String) {
         myFixture.configureByText(KotlinFileType.INSTANCE, code)
         val gutterMarks = myFixture.findAllGutters()
-        assertSize(1, gutterMarks)
-        val actualColorIcon = gutterMarks[0].icon as? ColorIcon
-        assertEquals(expected, actualColorIcon?.iconColor)
+        assertNotEmpty(gutterMarks)
+        val iconGutterMark = gutterMarks.first { it.icon is ColorIcon }
+        val actualColorIcon = iconGutterMark.icon as ColorIcon
+        assertEquals(expected, actualColorIcon.iconColor)
     }
 
     /**
@@ -39,9 +40,10 @@ class ColorRGBaColorProviderTest : ColorRGBaTestCase() {
     ) {
         myFixture.configureByText(KotlinFileType.INSTANCE, code)
         val gutterMarks = myFixture.findAllGutters()
-        assertSize(1, gutterMarks)
+        assertNotEmpty(gutterMarks)
+        val iconGutterMark = gutterMarks.first { it.icon is ColorsIcon }
+        val actualColorsIcon = iconGutterMark.icon as ColorsIcon
         val expectedColorsIcon = ColorsIcon(12, *expected.reversedArray())
-        val actualColorsIcon = gutterMarks[0].icon as? ColorsIcon
         assertEquals(expectedColorsIcon, actualColorsIcon)
     }
 


### PR DESCRIPTION
Newer version of IntelliJ lets us fix a bug with the dependencies in tests.